### PR TITLE
Logging for console commands added

### DIFF
--- a/Airbrake/CONSOLE_README.md
+++ b/Airbrake/CONSOLE_README.md
@@ -1,0 +1,25 @@
+Example app/console using Airbrake ConsoleClient
+
+```php
+#!/usr/bin/env php
+<?php
+
+// Set $env, $debug params etc
+
+$input = new ArgvInput();
+
+$kernel = new AppKernel($env, $debug);
+$application = new Application($kernel);
+$application->setCatchExceptions(false);
+
+try{
+    $application->run($input);
+} catch (Exception $e){
+    $client = $kernel->getContainer()->get('php_airbrake.console_client');
+    $client->setCommand($input->getFirstArgument());
+    $client->notifyOnException($e);
+
+    echo 'Exception - '.$e->getMessage();
+}
+
+```

--- a/Airbrake/Client.php
+++ b/Airbrake/Client.php
@@ -25,6 +25,7 @@ class Client extends AirbrakeClient
      * @param string $apiKey
      * @param Symfony\Component\DependencyInjection\ContainerInterface $container
      * @param string|null $queue
+     * @param string|null $apiEndPoint
      */
     public function __construct($apiKey, $envName, ContainerInterface $container, $queue=null, $apiEndPoint=null)
     {

--- a/Airbrake/ConsoleClient.php
+++ b/Airbrake/ConsoleClient.php
@@ -1,0 +1,47 @@
+<?php
+namespace Nodrew\Bundle\PhpAirbrakeBundle\Airbrake;
+
+use Airbrake\Notice;
+use Airbrake\Configuration as AirbrakeConfiguration;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * The PhpAirbrakeBundle Console Client Loader.
+ *
+ * @package		Airbrake
+ * @license		http://www.opensource.org/licenses/mit-license.php
+ */
+class Client extends Client
+{
+    protected $enabled = false;
+
+    /**
+     * @param string $apiKey
+     * @param Symfony\Component\DependencyInjection\ContainerInterface $container
+     * @param string|null $queue
+     */
+    public function __construct($apiKey, $envName, ContainerInterface $container, $queue=null, $apiEndPoint=null)
+    {
+        if (!$apiKey) {
+            return;
+        }
+
+        $this->enabled = true;
+        $controller    = 'None';
+
+        $options = array(
+            'environmentName' => $envName,
+            'queue'           => $queue,
+            'component'       => 'console',
+            'action'          => 'none',
+            'projectRoot'     => realpath($container->getParameter('kernel.root_dir').'/..'),
+        );
+
+        if(!empty($apiEndPoint)){
+            $options['apiEndPoint'] = $apiEndPoint;
+        }
+
+        parent::__construct(new AirbrakeConfiguration($apiKey, $options));
+
+    }
+}

--- a/Airbrake/ConsoleClient.php
+++ b/Airbrake/ConsoleClient.php
@@ -1,6 +1,7 @@
 <?php
 namespace Nodrew\Bundle\PhpAirbrakeBundle\Airbrake;
 
+use Airbrake\Client as AirbrakeClient;
 use Airbrake\Notice;
 use Airbrake\Configuration as AirbrakeConfiguration;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -11,7 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @package		Airbrake
  * @license		http://www.opensource.org/licenses/mit-license.php
  */
-class ConsoleClient extends Client
+class ConsoleClient extends AirbrakeClient
 {
     protected $enabled = false;
 
@@ -19,6 +20,7 @@ class ConsoleClient extends Client
      * @param string $apiKey
      * @param Symfony\Component\DependencyInjection\ContainerInterface $container
      * @param string|null $queue
+     * @param string|null $apiEndPoint
      */
     public function __construct($apiKey, $envName, ContainerInterface $container, $queue=null, $apiEndPoint=null)
     {
@@ -43,5 +45,20 @@ class ConsoleClient extends Client
 
         parent::__construct(new AirbrakeConfiguration($apiKey, $options));
 
+    }
+
+    /**
+     * Notify about the notice.
+     *
+     * If there is a PHP Resque client given in the configuration, then use that to queue up a job to
+     * send this out later. This should help speed up operations.
+     *
+     * @param Airbrake\Notice $notice
+     */
+    public function notify(Notice $notice)
+    {
+        if ($this->enabled) {
+            parent::notify($notice);
+        }
     }
 }

--- a/Airbrake/ConsoleClient.php
+++ b/Airbrake/ConsoleClient.php
@@ -47,6 +47,11 @@ class ConsoleClient extends AirbrakeClient
 
     }
 
+    public function setCommand($name)
+    {
+        $this->configuration->_action = $name;
+    }
+
     /**
      * Notify about the notice.
      *

--- a/Airbrake/ConsoleClient.php
+++ b/Airbrake/ConsoleClient.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @package		Airbrake
  * @license		http://www.opensource.org/licenses/mit-license.php
  */
-class Client extends Client
+class ConsoleClient extends Client
 {
     protected $enabled = false;
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,12 +9,21 @@
         <parameter key="php_airbrake.api_endpoint"></parameter>
         <parameter key="php_airbrake.queue"></parameter>
         <parameter key="php_airbrake.client.class">Nodrew\Bundle\PhpAirbrakeBundle\Airbrake\Client</parameter>
+        <parameter key="php_airbrake.console_client.class">Nodrew\Bundle\PhpAirbrakeBundle\Airbrake\ConsoleClient</parameter>
         <parameter key="php_airbrake.exception_listener.class">Nodrew\Bundle\PhpAirbrakeBundle\EventListener\ExceptionListener</parameter>
         <parameter key="php_airbrake.shutdown_listener.class">Nodrew\Bundle\PhpAirbrakeBundle\EventListener\ShutdownListener</parameter>
     </parameters>
 
     <services>
         <service id="php_airbrake.client" class="%php_airbrake.client.class%">
+            <argument>%php_airbrake.api_key%</argument>
+            <argument>%kernel.environment%</argument>
+            <argument type="service" id="service_container" />
+            <argument>%php_airbrake.queue%</argument>
+            <argument>%php_airbrake.api_endpoint%</argument>
+        </service>
+
+        <service id="php_airbrake.console_client" class="%php_airbrake.console_client.class%">
             <argument>%php_airbrake.api_key%</argument>
             <argument>%kernel.environment%</argument>
             <argument type="service" id="service_container" />

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,8 @@
 {
-    "name": "nodrew/php-airbrake-bundle",
+    "name": "musicglue/php-airbrake-bundle",
     "description": "This helps binds the php-airbrake module into a Symfony2 bundle for easy use with the framework.",
     "type": "symfony-bundle",
     "keywords": ["logging", "exceptions", "airbrake"],
-    "homepage": "https://github.com/nodrew/PhpAirbrakeBundle",
     "license": "MIT",
     "authors": [
         {
@@ -16,7 +15,7 @@
         "dbtlr/php-airbrake": "dev-master"
     },
     "autoload": {
-        "psr-0": { "Nodrew\\Bundle\\PhpAirbrakeBundle": "" }
+        "psr-0": { "MusicGlue\\Bundle\\PhpAirbrakeBundle": "" }
     },
-    "target-dir": "Nodrew/Bundle/PhpAirbrakeBundle"
+    "target-dir": "MusicGlue/Bundle/PhpAirbrakeBundle"
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.1",        
-        "nodrew/php-airbrake": "dev-master"
+        "dbtlr/php-airbrake": "dev-master"
     },
     "autoload": {
         "psr-0": { "Nodrew\\Bundle\\PhpAirbrakeBundle": "" }


### PR DESCRIPTION
Hey there,

I appreciate this is a bit of a hack and not utilising airbrake as it is intended, however I have found it useful for logging issues in console commands that are run as background jobs (e.g. cron tasks / daemons).

I'll leave it up to you to decide whether or not it is something you wish to support in your bundle.

See Airbrake/CONSOLE_README.md for more info

Cheers
Tom
