### PR TITLE
Don't start sessions

### DIFF
--- a/Airbrake/Client.php
+++ b/Airbrake/Client.php
@@ -58,7 +58,7 @@ class Client extends AirbrakeClient
             $serverData     = $request->server->all();
             $getData        = $request->query->all();
             $postData       = $request->request->all();
-            $sessionData    = $request->getSession() ? $request->getSession()->all() : null;
+            $sessionData    = $request->getSession() && $request->getSession()->isStarted() ? $request->getSession()->all() : null;
             $component      = $controller;
 
         }

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,8 @@
         "psr-4": { "Nodrew\\Bundle\\PhpAirbrakeBundle\\Test\\": "tests" }
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.6"
+        "phpunit/phpunit": "^5.6",
+        "symfony/dependency-injection": "^2.8",
+        "symfony/http-kernel": "^2.8"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,17 @@
         }
     ],
     "require": {
-        "php": ">=5.3.1",        
+        "php": ">=5.3.1",
         "dbtlr/php-airbrake": "^1.1"
     },
     "autoload": {
         "psr-0": { "Nodrew\\Bundle\\PhpAirbrakeBundle": "" }
     },
-    "target-dir": "Nodrew/Bundle/PhpAirbrakeBundle"
+    "target-dir": "Nodrew/Bundle/PhpAirbrakeBundle",
+    "autoload-dev": {
+        "psr-4": { "Nodrew\\Bundle\\PhpAirbrakeBundle\\Test\\": "tests" }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.6"
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        processIsolation="true"
+        stopOnFailure="false"
+        syntaxCheck="false"
+        bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="UnitTests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,0 +1,92 @@
+<?php
+namespace Nodrew\Bundle\PhpAirbrakeBundle\Airbrake\Tests;
+
+use Nodrew\Bundle\PhpAirbrakeBundle\Airbrake\Client;
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+class ClientTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerInterface|PHPUnit_Framework_MockObject_MockObject
+     */
+    private $container;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->container = $this->createMock(ContainerInterface::class);
+    }
+
+    public function testCreateNullSession()
+    {
+        $request = Request::create('/some-url');
+
+        $this->container
+            ->method('get')->with('request')
+            ->willReturn($request);
+
+        new Client(
+            'api_key',
+            'some_env',
+            $this->container,
+            'some_queue',
+            'http://some.api/endpoint',
+            false
+        );
+    }
+
+    public function testCreateUnstartedSession()
+    {
+        $session = $this->createMock(Session::class);
+        $session->method('isStarted')->willReturn(false);
+        $session->expects(static::never())->method('has');
+        $session->expects(static::never())->method('get');
+        $session->expects(static::never())->method('set');
+        $session->expects(static::never())->method('all');
+        $session->expects(static::never())->method('replace');
+        $session->expects(static::never())->method('remove');
+        $session->expects(static::never())->method('clear');
+
+        $request = Request::create('/some-url');
+        $request->setSession($session);
+
+        $this->container
+            ->method('get')->with('request')
+            ->willReturn($request);
+
+        new Client(
+            'api_key',
+            'some_env',
+            $this->container,
+            'some_queue',
+            'http://some.api/endpoint',
+            false
+        );
+    }
+
+    public function testCreateWithSession()
+    {
+        $session = $this->createMock(Session::class);
+        $session->method('isStarted')->willReturn(true);
+
+        $request = Request::create('/some-url');
+        $request->setSession($session);
+
+        $this->container
+            ->method('get')->with('request')
+            ->willReturn($request);
+
+        new Client(
+            'api_key',
+            'some_env',
+            $this->container,
+            'some_queue',
+            'http://some.api/endpoint',
+            false
+        );
+    }
+}


### PR DESCRIPTION
Fix applied from ibrows/PhpAirbrakeBundle#1

Do not start uninitialized Sessions.

Requesting data from the session will actually initialise the session.
symfony/symfony#6036

Also PHPUnit was installed.
